### PR TITLE
Do not Emit Empty Documents from SearchOutput

### DIFF
--- a/subprojects/lettucemod/src/main/java/com/redis/lettucemod/output/SearchOutput.java
+++ b/subprojects/lettucemod/src/main/java/com/redis/lettucemod/output/SearchOutput.java
@@ -47,7 +47,6 @@ public class SearchOutput<K, V> extends CommandOutput<K, V, SearchResults<K, V>>
 			if (bytes != null) {
 				current.setId(codec.decodeKey(bytes));
 			}
-			output.add(current);
 			return;
 		}
 		if (withScores && !scoreSet) {
@@ -92,10 +91,12 @@ public class SearchOutput<K, V> extends CommandOutput<K, V, SearchResults<K, V>>
 		if (counts.isEmpty()) {
 			return;
 		}
+        int nestedSize = nested.get().size();
 		if (nested.get().size() == counts.get(0)) {
 			counts.remove(0);
-			if (current != null) {
+			if (current != null && nestedSize > 0) {
 				current.putAll(nested.get());
+                output.add(current);
 			}
 			nested = new MapOutput<>(codec);
 			current = null;


### PR DESCRIPTION
There are no unit tests for `SearchOutput` and the issue cannot easily be reproduced. Hence, this is untested. I am happy to provide tests if you give guidance how.

fixes #21